### PR TITLE
bp.Quantizer: fixed importing bp.scales.json (see #62)

### DIFF
--- a/clippings/BEAP/Quantizer/bp.Quantizer.maxpat
+++ b/clippings/BEAP/Quantizer/bp.Quantizer.maxpat
@@ -1996,7 +1996,7 @@
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 638.130615, 115.646873, 114.0, 22.0 ],
 									"style" : "",
-									"text" : "read bp.scales.json"
+									"text" : "import bp.scales.json"
 								}
 
 							}


### PR DESCRIPTION
I just fixed bp.Quantizer's abstraction in this pull request.